### PR TITLE
Fix README typo and add health endpoint documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ npm run dev
 
 This will start the simulator on http://localhost:3000
 
-Accessing the room of the domain will show the dashboard view of the server. The dashboard allows you to set the environment variables for the server and view the logs of the server.
+Accessing the root of the domain will show the dashboard view of the server. The dashboard allows you to set the environment variables for the server and view the logs of the server.
 
 There are helpful links to the Investec docs, Community wiki, GitHub repo and the Postman collection.
 
@@ -54,6 +54,8 @@ There are helpful links to the Investec docs, Community wiki, GitHub repo and th
 ### Dashboard
 - **GET /**
     - Dashboard view of the server
+- **GET /health**
+    - Health check endpoint returning service status
 ### Auth
 - **POST /identity/v2/oauth2/token**
     - Get an access token (only required if auth is turned on)


### PR DESCRIPTION
## Summary
- Fixed a typo in the README documentation
- Added missing health endpoint documentation
- Maintained original formatting and structure

## Changes Made
- **Typo Fix**: Changed "Accessing the room of the domain" to "Accessing the root of the domain" (line 48)
- **Documentation Addition**: Added `/health` endpoint to the Dashboard endpoints section
- **Format Preservation**: Kept all original formatting, links, and repository references intact

## Rationale
- The typo was a clear error that needed correction
- The health endpoint was recently added but not documented in the README
- Changes are minimal and only address necessary corrections
- Original repository structure and references preserved

## Test plan
- [x] Verify README renders correctly in GitHub
- [x] Confirm all links still work
- [x] Check that formatting is preserved
- [x] Validate health endpoint documentation is accurate